### PR TITLE
Command prepend

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Make sure to define `COVERITY_SCAN_TOKEN` in your
     # Default: 'linux64'
     build_platform: ''
 
+    # Command to prepare for build.
+    #
+    # Default: ''
+    command_prepend: ''
+
     # Command to pass to cov-build.
     #
     # Default: 'make'

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: Which Coverity Scan platform pack to download.
     default: linux64
 
+  command_prepend:
+    description: Command to prepare for build.
+    default: 
+
   command:
     description: Command to pass to cov-build.
     default: make
@@ -54,6 +58,7 @@ runs:
     - name: Build with cov-build
       run: |
         export PATH="${PWD}/cov-analysis/bin:${PATH}"
+        ${{ inputs.command_prepend }}
         cov-build --dir cov-int ${{ inputs.command }}
       shell: bash
 


### PR DESCRIPTION
For my project, I need to generate some build files with cmake before the ninja build can be started.

This PR will add a `command_prepend` to the possible arguments. This is a command that is executed before the actual build is executed.