### PR TITLE
Encode the project name with space

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,8 +51,9 @@ runs:
   using: composite
   steps:
     # Need to encode the project name when using in URLs and HTTP forms.  Valid
-    # GitHub project names only have / that need encoding, so do an ad-hoc conversion
-    # here.  Wait to see if anyone needs something else.
+    # GitHub project names only have / that need encoding and
+    # Coverity projects with spaces in their names need encoding so do
+    # an ad-hoc conversion here.  Wait to see if anyone needs something else.
     - name: URL encode project name
       id: project
       run: echo "project=${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /%20/g' >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
     # here.  Wait to see if anyone needs something else.
     - name: URL encode project name
       id: project
-      run: echo "::set-output name=project::${{ inputs.project }}" | sed -e 's:/:%2F:g'
+      run: echo "::set-output name=project::${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /+/g'
       shell: bash
 
     # The Coverity site says the tool is usually updated twice yearly, so the

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
     # here.  Wait to see if anyone needs something else.
     - name: URL encode project name
       id: project
-      run: echo "project=${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /+/g' >> $GITHUB_OUTPUT
+      run: echo "project=${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /%20/g' >> $GITHUB_OUTPUT
       shell: bash
 
     # The Coverity site says the tool is usually updated twice yearly, so the


### PR DESCRIPTION
This is for encoding project name having space.
Reference: https://scan.coverity.com/projects/ohloh-ui 