### PR TITLE
Update to latest actions/cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
     # Cache miss will add ~30s to create, but cache hit will save minutes.
     - name: Cache Coverity Build Tool
       id: cov-build-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ inputs.working-directory }}/cov-analysis
         key: cov-build-${{ inputs.build_language }}-${{ inputs.build_platform }}-${{ steps.coverity-cache-lookup.outputs.hash }}


### PR DESCRIPTION
Since v2 triggers deprecation warnings, switch to v3.