### PR TITLE
Update to actions/cache@v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
     # Cache miss will add ~30s to create, but cache hit will save minutes.
     - name: Cache Coverity Build Tool
       id: cov-build-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.working-directory }}/cov-analysis
         key: cov-build-${{ inputs.build_language }}-${{ inputs.build_platform }}-${{ steps.coverity-cache-lookup.outputs.hash }}


### PR DESCRIPTION
This currently fixes the following warning:

    Node.js 16 actions are deprecated. Please update the
    following actions to use Node.js 20: actions/cache@v3.
    For more information see:
    https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This warning will likely turn into an error when Node.js 16 support is turned off.