### PR TITLE
Add a dry_run option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,11 @@ inputs:
     default: coverity-scan-action ${{ github.repository }} / ${{ github.ref }}
     required: false
 
+  dry_run:
+    description: Do everything except the final submission to Coverity Scan.
+    default: false
+    required: false
+
 runs:
   using: composite
   steps:
@@ -113,6 +118,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Submit results to Coverity Scan
+      if: ${{ ! inputs.dry_run }}
       run: |
         curl \
           --form token="${TOKEN}" \


### PR DESCRIPTION
This lets people trial their Coverity action environment/setup without making final submissions for analysis.

Example: https://github.com/andyhhp/xen/actions/runs/9843491247/job/27174800430