### PR TITLE
FIX: Character encoding update in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,12 @@ runs:
     # an ad-hoc conversion here.  Wait to see if anyone needs something else.
     - name: URL encode project name
       id: project
-      run: echo "project=${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /%20/g' >> $GITHUB_OUTPUT
+      run: |
+        if command -v jq 2>&1 >/dev/null; then 
+          jq -rn --arg x "${{ inputs.project }}" '$x|"project="+@uri' >> $GITHUB_OUTPUT
+        else
+          echo "project=${{ inputs.project }}" | sed -e 's:/:%2F:g' -e 's/ /%20/g' >> $GITHUB_OUTPUT
+        fi
       shell: bash
 
     # The Coverity site says the tool is usually updated twice yearly, so the


### PR DESCRIPTION
FIX: Character encoding update in `action.yml` by adding `jq` based `url` encoding wrapped in a bash check for backward compatibility. This allows special characters in project name like for example `®`.